### PR TITLE
Refactor import paths and reorganize PlayerArchetypeData interface

### DIFF
--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -1,10 +1,10 @@
 import { VitalPointSeverity } from "../types/common";
-import { CombatResult, CombatSystemInterface } from "./combat";
+import { CombatResult, CombatSystemInterface } from "./combat/types";
 import { PlayerState } from "./player";
 import { TRIGRAM_TECHNIQUES } from "./trigram";
 import { TrigramSystem } from "./TrigramSystem";
 import { StatusEffect } from "./types";
-import { KoreanTechnique, VitalPointHitResult } from "./vitalpoint";
+import { KoreanTechnique, VitalPointHitResult } from "./vitalpoint/types";
 import { VitalPointSystem } from "./VitalPointSystem";
 
 export class CombatSystem implements CombatSystemInterface {

--- a/src/systems/combat/types.ts
+++ b/src/systems/combat/types.ts
@@ -8,8 +8,7 @@
 import { GameMode, GamePhase, Position, TrigramStance } from "@/types";
 import { PlayerMatchStats, PlayerState } from "../player";
 import { StatusEffect } from "../types";
-import { VitalPointHitResult } from "../vitalpoint";
-import { KoreanTechnique } from "../vitalpoint/types";
+import { KoreanTechnique, VitalPointHitResult } from "../vitalpoint/types";
 
 export interface CombatResult {
   readonly success: boolean;

--- a/src/systems/types.ts
+++ b/src/systems/types.ts
@@ -53,7 +53,35 @@ import type {
   DisplayObject as PixiDisplayObject,
   Texture,
 } from "pixi.js";
-import { PlayerArchetypeData } from "./vitalpoint/types";
+
+// Vital point effect
+// Player archetype data
+export interface PlayerArchetypeData {
+  readonly id: string;
+  readonly name: KoreanText;
+  readonly description: KoreanText;
+  readonly baseHealth: number;
+  readonly baseKi: number;
+  readonly baseStamina: number;
+  readonly coreStance: TrigramStance;
+  readonly theme: {
+    primary: number;
+    secondary: number;
+  };
+  readonly colors: {
+    primary: number;
+    secondary: number;
+  };
+  readonly stats: {
+    attackPower: number;
+    defense: number;
+    speed: number;
+    technique: number;
+  };
+  readonly favoredStances: readonly TrigramStance[];
+  readonly specialAbilities: readonly string[];
+  readonly philosophy: KoreanText;
+}
 
 export interface AnimationState {
   readonly currentAnimationName?: string;

--- a/src/systems/types.ts
+++ b/src/systems/types.ts
@@ -53,7 +53,7 @@ import type {
   DisplayObject as PixiDisplayObject,
   Texture,
 } from "pixi.js";
-import { PlayerArchetypeData } from "./vitalpoint";
+import { PlayerArchetypeData } from "./vitalpoint/types";
 
 export interface AnimationState {
   readonly currentAnimationName?: string;

--- a/src/systems/vitalpoint/types.ts
+++ b/src/systems/vitalpoint/types.ts
@@ -209,35 +209,6 @@ export interface VitalPointEffect {
   readonly source?: string;
 }
 
-// Vital point effect
-// Player archetype data
-export interface PlayerArchetypeData {
-  readonly id: string;
-  readonly name: KoreanText;
-  readonly description: KoreanText;
-  readonly baseHealth: number;
-  readonly baseKi: number;
-  readonly baseStamina: number;
-  readonly coreStance: TrigramStance;
-  readonly theme: {
-    primary: number;
-    secondary: number;
-  };
-  readonly colors: {
-    primary: number;
-    secondary: number;
-  };
-  readonly stats: {
-    attackPower: number;
-    defense: number;
-    speed: number;
-    technique: number;
-  };
-  readonly favoredStances: readonly TrigramStance[];
-  readonly specialAbilities: readonly string[];
-  readonly philosophy: KoreanText;
-}
-
 // Region data
 export interface RegionData {
   readonly name: KoreanText;


### PR DESCRIPTION
Improve code organization and clarity by refactoring import paths in CombatSystem and PlayerArchetypeData, and moving the PlayerArchetypeData interface to types.ts.