### PR TITLE
Update typedoc to version 0.28.9 and clean up dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "start-server-and-test": "^2.0.12",
         "ts-morph": "^26.0.0",
         "ts-node": "^10.9.2",
-        "typedoc": "^0.28.8",
+        "typedoc": "^0.28.9",
         "typedoc-plugin-markdown": "^4.8.0",
         "typedoc-plugin-mermaid": "^1.12.0",
         "typedoc-plugin-missing-exports": "^4.0.0",
@@ -71,10 +71,6 @@
         "vite-bundle-analyzer": "^1.1.0",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1402,15 +1398,16 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.7.0.tgz",
-      "integrity": "sha512-7iY9wg4FWXmeoFJpUL2u+tsmh0d0jcEJHAIzVxl3TG4KL493JNnisdLAILZ77zcD+z3J0keEXZ+lFzUgzQzPDg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.9.1.tgz",
+      "integrity": "sha512-quvtbDhNf528BkMHQQd8xGJMpmA5taDZuex/JDF8ETEjS2iypXzr1hnEUVh+lTUyffFJ0JCxysUsiuUoEGIz/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.7.0",
-        "@shikijs/langs": "^3.7.0",
-        "@shikijs/themes": "^3.7.0",
-        "@shikijs/types": "^3.7.0",
+        "@shikijs/engine-oniguruma": "^3.9.1",
+        "@shikijs/langs": "^3.9.1",
+        "@shikijs/themes": "^3.9.1",
+        "@shikijs/types": "^3.9.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -2393,38 +2390,42 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
-      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.9.1.tgz",
+      "integrity": "sha512-WPlL/xqviwS3te4unSGGGfflKsuHLMI6tPdNYvgz/IygcBT6UiwDFSzjBKyebwi5GGSlXsjjdoJLIBnAplmEZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0",
+        "@shikijs/types": "3.9.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
-      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.9.1.tgz",
+      "integrity": "sha512-Vyy2Yv9PP3Veh3VSsIvNncOR+O93wFsNYgN2B6cCCJlS7H9SKFYc55edsqernsg8WT/zam1cfB6llJsQWLnVhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.9.1"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
-      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.9.1.tgz",
+      "integrity": "sha512-zAykkGECNICCMXpKeVvq04yqwaSuAIvrf8MjsU5bzskfg4XreU+O0B5wdNCYRixoB9snd3YlZ373WV5E/g5T9A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.9.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.9.1.tgz",
+      "integrity": "sha512-rqM3T7a0iM1oPKz9iaH/cVgNX9Vz1HERcUcXJ94/fulgVdwqfnhXzGxO4bLrAnh/o5CPLy3IcYedogfV+Ns0Qg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
@@ -2434,7 +2435,8 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -2969,6 +2971,7 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -3189,7 +3192,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webpack": {
       "version": "4.41.40",
@@ -16210,13 +16214,13 @@
       "license": "CC0-1.0"
     },
     "node_modules/typedoc": {
-      "version": "0.28.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.8.tgz",
-      "integrity": "sha512-16GfLopc8icHfdvqZDqdGBoS2AieIRP2rpf9mU+MgN+gGLyEQvAO0QgOa6NJ5QNmQi0LFrDY9in4F2fUNKgJKA==",
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.9.tgz",
+      "integrity": "sha512-aw45vwtwOl3QkUAmWCnLV9QW1xY+FSX2zzlit4MAfE99wX+Jij4ycnpbAWgBXsRrxmfs9LaYktg/eX5Bpthd3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.7.0",
+        "@gerrit0/mini-shiki": "^3.9.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
@@ -16230,7 +16234,7 @@
         "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
       }
     },
     "node_modules/typedoc-plugin-markdown": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "start-server-and-test": "^2.0.12",
     "ts-morph": "^26.0.0",
     "ts-node": "^10.9.2",
-    "typedoc": "^0.28.8",
+    "typedoc": "^0.28.9",
     "typedoc-plugin-markdown": "^4.8.0",
     "typedoc-plugin-mermaid": "^1.12.0",
     "typedoc-plugin-missing-exports": "^4.0.0",
@@ -103,23 +103,5 @@
     "vite-bundle-analyzer": "^1.1.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
-  },
-  "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "overrides": {
-    "@testing-library/react": {
-      "react": "^19.0.0",
-      "react-dom": "^19.0.0"
-    },
-    "@cypress/react": {
-      "react": "^19.0.0",
-      "react-dom": "^19.0.0"
-    }
-  },
-  "resolutions": {
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
   }
 }


### PR DESCRIPTION
Upgrade typedoc to the latest version and remove unused peerDependencies and overrides for a cleaner configuration.